### PR TITLE
available workaround used with `include`

### DIFF
--- a/index.js
+++ b/index.js
@@ -131,6 +131,8 @@ module.exports = function plugin(app) {
    */
 
   app.asyncHelper('ifExists', function(files, val, cb) {
+    val = typeof val === 'function' ? val() : val;
+    
     cb(null, utils.anyExists(files, this.app.cwd) ? val : '');
   });
 


### PR DESCRIPTION
fixes https://github.com/verbose/verb-generate-readme/issues/29

allows lazy load of include only if file exists.